### PR TITLE
[HOTFIX] hasChildren not defined in Symfony 2.3

### DIFF
--- a/Comment/pvrEzCommentManager.php
+++ b/Comment/pvrEzCommentManager.php
@@ -309,13 +309,13 @@ class pvrEzCommentManager implements pvrEzCommentManagerInterface
 
             $errors[$key] = $template;
         }
-        if ($form->hasChildren()) {
-            foreach ($form->getChildren() as $child) {
-                if (!$child->isValid()) {
-                    $errors[$child->getName()] = $this->getErrorMessages($child);
-                }
+        foreach ($form->all() as $key => $child) {
+            /** @var $child Form */
+            if ($err = $this->getErrorMessages($child)) {
+                $errors[$key] = $err;
             }
         }
+        
         return $errors;
     }
 


### PR DESCRIPTION
Error: Call to undefined method Symfony\Component\Form\Form::hasChildren()

hasChildren not defined in Symfony 2.3
