### PR TITLE
Symfony 2.7 use of the TranslatorInterface instead of the Translator class

### DIFF
--- a/Comment/pvrEzCommentManager.php
+++ b/Comment/pvrEzCommentManager.php
@@ -19,7 +19,7 @@ use pvr\EzCommentBundle\Comment\PvrEzCommentManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Collection;
@@ -39,7 +39,7 @@ class PvrEzCommentManager implements PvrEzCommentManagerInterface
     protected $moderate_to;
     protected $moderate_template;
     protected $isNotify;
-    /** @var  $translator \Symfony\Component\Translation\Translator */
+    /** @var  $translator \Symfony\Component\Translation\TranslatorInterface */
     protected $translator;
     /** @var $formFactory  \Symfony\Component\Form\FormFactory */
     protected $formFactory;
@@ -62,9 +62,9 @@ class PvrEzCommentManager implements PvrEzCommentManagerInterface
     }
 
     /**
-     * @param Translator $translator
+     * @param TranslatorInterface $translator
      */
-    public function setTranslator( Translator $translator )
+    public function setTranslator( TranslatorInterface $translator )
     {
         $this->translator = $translator;
     }

--- a/Service/Comment.php
+++ b/Service/Comment.php
@@ -8,7 +8,7 @@ use pvr\EzCommentBundle\Comment\PvrEzCommentManager;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\SecurityContext;
-use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
 
 
 class Comment
@@ -25,12 +25,12 @@ class Comment
      * @param PvrEzCommentManager $contentManager
      * @param $connection
      * @param LocaleConverter $locale
-     * @param Translator $translator
+     * @param TranslatorInterface $translator
      * @param Repository $repository
      */
     public function __construct(
         PvrEzCommentManager $contentManager, $connection,
-        LocaleConverter $locale, Translator $translator,
+        LocaleConverter $locale, TranslatorInterface $translator,
         Repository $repository
     )
     {


### PR DESCRIPTION
Hi Philippe,

This extension was not working anymore with the last Symfony2 version because of this.

Have a nice day.