### PR TITLE
Composer command use the last version (doc)

### DIFF
--- a/Resources/doc/1-install_dependencies.md
+++ b/Resources/doc/1-install_dependencies.md
@@ -11,7 +11,7 @@ In order to work fully, this bundle need to have some dependencies:
 
 If you use eZ Publish 5.4 or last community version ( >= 2014.11 )
 ```
-php composer.phar require --prefer-dist dspe/pvrezcommentbundle:v0.2
+php composer.phar require --prefer-dist dspe/pvrezcommentbundle:@dev
 ```
 
 ```


### PR DESCRIPTION
I am not sure it is the best thing to do. Maybe a tag would be better. Without this, we don't get the working version of this bundle anyway.